### PR TITLE
fix: Add jest-specific tsconfig to fix tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2470,6 +2470,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@zeit/next-css/-/next-css-1.0.1.tgz",
       "integrity": "sha512-yfHPRy/ne/5SddVClsoy+fpU7e0Cs1gkWA67/wm2uIu+9rznF45yQLxHEt5dPGF3h6IiIh7ZtIgA8VV8YKq87A==",
+      "dev": true,
       "requires": {
         "css-loader": "1.0.0",
         "extracted-loader": "1.0.4",
@@ -2483,6 +2484,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
           "integrity": "sha512-tMXlTYf3mIMt3b0dDCOQFJiVvxbocJ5Ho577WiGPYPZcqVEO218L2iU22pDXzkTZCLDE+9AmGSUkWxeh/nZReA==",
+          "dev": true,
           "requires": {
             "babel-code-frame": "^6.26.0",
             "css-selector-tokenizer": "^0.7.0",
@@ -2502,6 +2504,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
           "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+          "dev": true,
           "requires": {
             "postcss": "^6.0.1"
           }
@@ -2510,6 +2513,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -2518,6 +2522,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
           "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -2528,6 +2533,7 @@
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.3.tgz",
           "integrity": "sha512-Mxs0nxzF1kxPv4TRi2NimewgXlJqh0rGE30vviCU2WHrpbta6wklnUV9dr9FUtoAHmB3p3LeXEC+ZjgHvB0Dzg==",
+          "dev": true,
           "requires": {
             "loader-utils": "^1.1.0",
             "schema-utils": "^1.0.0",
@@ -2538,6 +2544,7 @@
           "version": "6.0.23",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
           "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
           "requires": {
             "chalk": "^2.4.1",
             "source-map": "^0.6.1",
@@ -2548,6 +2555,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
           "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+          "dev": true,
           "requires": {
             "postcss": "^6.0.1"
           }
@@ -2556,6 +2564,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
           "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+          "dev": true,
           "requires": {
             "css-selector-tokenizer": "^0.7.0",
             "postcss": "^6.0.1"
@@ -2565,6 +2574,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
           "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+          "dev": true,
           "requires": {
             "css-selector-tokenizer": "^0.7.0",
             "postcss": "^6.0.1"
@@ -2574,6 +2584,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
           "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+          "dev": true,
           "requires": {
             "icss-replace-symbols": "^1.1.0",
             "postcss": "^6.0.1"
@@ -2582,12 +2593,14 @@
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
         },
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
           "requires": {
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",
@@ -2600,6 +2613,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@zeit/next-sass/-/next-sass-1.0.1.tgz",
       "integrity": "sha512-QVmrsLye85gtIYj+QSBuFadzd6NQgI5DZfqlV+ET1nXI3B+C91wAaJN71O98KMvNIc8R2QLosxugEyd2V5wE6w==",
+      "dev": true,
       "requires": {
         "@zeit/next-css": "1.0.1",
         "sass-loader": "6.0.6"
@@ -2609,6 +2623,7 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
           "integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
+          "dev": true,
           "requires": {
             "for-own": "^1.0.0",
             "is-plain-object": "^2.0.1",
@@ -2620,6 +2635,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -2628,6 +2644,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2636,6 +2653,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
           "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -2645,12 +2663,14 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         },
         "sass-loader": {
           "version": "6.0.6",
           "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.6.tgz",
           "integrity": "sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==",
+          "dev": true,
           "requires": {
             "async": "^2.1.5",
             "clone-deep": "^0.3.0",
@@ -2663,6 +2683,7 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
           "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+          "dev": true,
           "requires": {
             "is-extendable": "^0.1.1",
             "kind-of": "^2.0.1",
@@ -2674,6 +2695,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
               "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.0.2"
               }
@@ -2966,6 +2988,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.14"
       }
@@ -4073,6 +4096,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.2.tgz",
       "integrity": "sha512-yj856NGuAymN6r8bn8/Jl46pR+OC3eEvAhfGYDUe7YPtTPAYrSSw4oAniZ9Y8T5B92hjhwTBLUen0/vKPxf6pw==",
+      "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
         "fastparse": "^1.1.2",
@@ -5188,7 +5212,8 @@
     "extracted-loader": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/extracted-loader/-/extracted-loader-1.0.4.tgz",
-      "integrity": "sha512-G8A0hT/WCWIjesZm7BwbWdST5dQ08GNnCpTrJT/k/FYzuiJwlV1gyWjnuoizOzAR4jpEYXG2J++JyEKN/EB26Q=="
+      "integrity": "sha512-G8A0hT/WCWIjesZm7BwbWdST5dQ08GNnCpTrJT/k/FYzuiJwlV1gyWjnuoizOzAR4jpEYXG2J++JyEKN/EB26Q==",
+      "dev": true
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -5215,7 +5240,8 @@
     "fastparse": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
-      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
+      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+      "dev": true
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -5321,6 +5347,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "dev": true,
       "requires": {
         "for-in": "^1.0.1"
       }
@@ -5755,7 +5782,8 @@
     "icss-replace-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
     },
     "icss-utils": {
       "version": "4.1.1",
@@ -5784,12 +5812,14 @@
     "ignore-loader": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ignore-loader/-/ignore-loader-0.1.2.tgz",
-      "integrity": "sha1-2B8kA3bQuk8Nd4lyw60lh0EXpGM="
+      "integrity": "sha1-2B8kA3bQuk8Nd4lyw60lh0EXpGM=",
+      "dev": true
     },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+      "dev": true,
       "requires": {
         "import-from": "^2.1.0"
       }
@@ -5807,6 +5837,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+      "dev": true,
       "requires": {
         "resolve-from": "^3.0.0"
       }
@@ -8182,7 +8213,8 @@
     "lazy-cache": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-      "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+      "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+      "dev": true
     },
     "lcid": {
       "version": "1.0.0",
@@ -8271,7 +8303,8 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -8287,7 +8320,8 @@
     "lodash.tail": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
-      "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ="
+      "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
+      "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -8678,6 +8712,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "dev": true,
       "requires": {
         "for-in": "^0.1.3",
         "is-extendable": "^0.1.1"
@@ -8686,7 +8721,8 @@
         "for-in": {
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+          "dev": true
         }
       }
     },
@@ -9666,6 +9702,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
       "integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
+      "dev": true,
       "requires": {
         "cosmiconfig": "^5.0.0",
         "import-cwd": "^2.0.0"
@@ -9675,6 +9712,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
       "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
+      "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
         "postcss": "^7.0.0",
@@ -9686,6 +9724,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -9694,6 +9733,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
           "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -9704,6 +9744,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
           "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
           "requires": {
             "ajv": "^6.1.0",
             "ajv-errors": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
   "homepage": "https://github.com/techswitch-learners/testswitch-frontend-admin#readme",
   "jest": {
     "preset": "ts-jest",
+    "globals": {
+      "ts-jest": {
+        "tsConfig": "tsconfig.jest.json"
+      }
+    },
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react"
+    "jsx": "preserve"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
We found that running next start would modify our tsconfig.json so that jest couldn't parse react.

I've fixed this by adding a jest-specific extension to tsconfig.json - not an ideal fix, but it seems by far the easiest and worth it for a project this short.